### PR TITLE
Remove Behavior State's constructor

### DIFF
--- a/bots/lib/BehaviorStates/behaviorState.ts
+++ b/bots/lib/BehaviorStates/behaviorState.ts
@@ -5,11 +5,6 @@ export abstract class BehaviorState extends State {
 
   public currentActionState: ActionState;
 
-  constructor (initialState: ActionState, nextState: () => BehaviorState = undefined) {
-    super(nextState);
-    this.currentActionState = initialState;
-  }
-
   public async act () {
       this.currentActionState = await this.currentActionState.tick();
   }


### PR DESCRIPTION
It's been brought up that most of the time the assignment of the initial `currentActionState` is done in a extended BehaviorState's constructor. This is why the abstract BehaviorState constructor should be removed thus not enforcing the need to pass an initial ActionState from the outside.

Note: this doesn't imply it could not be done, just that it is more of the outlier than norm. 

Thoughts? Approval? 